### PR TITLE
[feat] 로그인 기능 구현

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,77 @@
-import React from "react";
+"use client";
+
+import React, { useState } from "react";
+import { useRouter } from "next/navigation";
 
 export default function LoginPage() {
+  const router = useRouter();
+  const [formData, setFormData] = useState({
+    email: "",
+    password: "",
+    rememberMe: false,
+  });
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value, type, checked } = e.target;
+    setFormData(prev => ({
+      ...prev,
+      [name]: type === "checkbox" ? checked : value,
+    }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setIsLoading(true);
+
+    try {
+      // 백엔드 서버로 로그인 요청
+      const backendUrl = 'http://localhost:8080';
+      
+      const response = await fetch(`${backendUrl}/api/auth/login`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          email: formData.email,
+          password: formData.password,
+        }),
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        
+        // 로그인 성공 시 토큰 저장
+        if (data.data) {
+          const { accessToken, refreshToken, memberInfo } = data.data;
+          
+          // AccessToken만 localStorage에 저장 (보안상 RefreshToken은 서버에서 관리)
+          localStorage.setItem('accessToken', accessToken);
+          
+          // 사용자 정보 저장
+          if (memberInfo) {
+            localStorage.setItem('userInfo', JSON.stringify(memberInfo));
+          }
+          
+          // 로그인 성공 시 메인 페이지로 리다이렉트
+          router.push("/");
+        } else {
+          setError("로그인 응답 데이터가 올바르지 않습니다.");
+        }
+      } else {
+        const errorData = await response.json();
+        setError(errorData.message || "이메일 또는 비밀번호가 잘못되었습니다.");
+      }
+    } catch (error) {
+      setError("서버 연결에 실패했습니다. 다시 시도해주세요.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   return (
     <div className="pb-10">
       <section className="px-6 py-8">
@@ -11,7 +82,13 @@ export default function LoginPage() {
               <p className="text-gray-600 text-sm">PatentMarket에 오신 것을 환영합니다</p>
             </div>
             
-            <form className="space-y-6">
+            {error && (
+              <div className="mb-4 p-3 bg-red-100 border border-red-400 text-red-700 rounded-lg">
+                {error}
+              </div>
+            )}
+            
+            <form className="space-y-6" onSubmit={handleSubmit}>
               <div>
                 <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
                   이메일
@@ -19,8 +96,12 @@ export default function LoginPage() {
                 <input
                   type="email"
                   id="email"
-                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500"
+                  name="email"
+                  value={formData.email}
+                  onChange={handleInputChange}
+                  className="w-full px-4 py-3 border text-black border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500"
                   placeholder="이메일을 입력하세요"
+                  required
                 />
               </div>
               
@@ -31,14 +112,24 @@ export default function LoginPage() {
                 <input
                   type="password"
                   id="password"
-                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500"
+                  name="password"
+                  value={formData.password}
+                  onChange={handleInputChange}
+                  className="w-full px-4 py-3 border text-black border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500"
                   placeholder="비밀번호를 입력하세요"
+                  required
                 />
               </div>
               
               <div className="flex items-center justify-between">
                 <label className="flex items-center">
-                  <input type="checkbox" className="rounded border-gray-300 text-purple-600 focus:ring-purple-500" />
+                  <input 
+                    type="checkbox" 
+                    name="rememberMe"
+                    checked={formData.rememberMe}
+                    onChange={handleInputChange}
+                    className="rounded border-gray-300 text-purple-600 focus:ring-purple-500" 
+                  />
                   <span className="ml-2 text-sm text-gray-600">로그인 상태 유지</span>
                 </label>
                 <a href="#" className="text-sm text-purple-600 hover:text-purple-700">
@@ -48,9 +139,10 @@ export default function LoginPage() {
               
               <button
                 type="submit"
-                className="w-full bg-purple-600 hover:bg-purple-700 text-white py-3 rounded-lg transition-colors font-medium"
+                disabled={isLoading}
+                className="w-full bg-purple-600 hover:bg-purple-700 disabled:bg-purple-400 text-white py-3 rounded-lg transition-colors font-medium"
               >
-                로그인
+                {isLoading ? "로그인 중..." : "로그인"}
               </button>
             </form>
             

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -27,8 +27,8 @@ export default function LoginPage() {
     setIsLoading(true);
 
     try {
-      // 백엔드 서버로 로그인 요청
-      const backendUrl = 'http://localhost:8080';
+      // 환경변수에서 백엔드 URL 가져오기
+      const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8080';
       
       const response = await fetch(`${backendUrl}/api/auth/login`, {
         method: "POST",


### PR DESCRIPTION
1. 로그인 기능 구현

== 아직 필요한 부분 ==
1. 로그인 여부에 따라 헤더 메뉴 바뀜
2. 로그인 여부에 따라 login url 직접 접근 차단
3. 로그아웃 기능 구현(redis적용 전, front에서 차단하는 방식 먼저 시도해볼 예정)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 로그인 페이지에서 입력값 상태 관리 및 에러 메시지 표시 기능이 추가되었습니다.
  * 로그인 시 로딩 상태와 버튼 비활성화, 성공 시 메인 페이지로 이동 및 사용자 정보 저장 기능이 도입되었습니다.

* **버그 수정**
  * 입력 필드에 필수 항목 표시 및 에러 메시지 표시 방식이 개선되었습니다.

* **스타일**
  * 입력창 및 버튼의 스타일이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->