### PR TITLE
[feat] 로그인 여부에 따른 헤더 변경, 로그아웃 기능 구현

### DIFF
--- a/USER_AUTH_GUIDE.md
+++ b/USER_AUTH_GUIDE.md
@@ -1,0 +1,190 @@
+# 사용자 인증 시스템 사용 가이드
+
+## 개요
+
+이 프로젝트는 React Context API를 사용하여 전역 사용자 인증 상태를 관리합니다. 로그인 상태에 따라 헤더 메뉴가 동적으로 변경되며, 모든 페이지에서 사용자 정보에 접근할 수 있습니다.
+
+## 주요 기능
+
+### 1. 로그인 상태에 따른 헤더 메뉴 변경
+
+- **로그인 전**: 홈, 특허목록, 로그인, 회원가입
+- **로그인 후**: 홈, 특허목록, 채팅, 마이페이지, 로그아웃
+
+### 2. 사용자 정보 관리
+
+- 쿠키를 통한 사용자 정보 저장 (7일간 유효)
+- 페이지 새로고침 시에도 로그인 상태 유지
+- 전역 상태로 모든 컴포넌트에서 사용자 정보 접근 가능
+
+## 사용법
+
+### 1. 다른 페이지에서 사용자 정보 가져오기
+
+```tsx
+'use client';
+
+import { useAuth } from '@/contexts/AuthContext';
+
+const MyComponent = () => {
+  const { user, isAuthenticated, loading } = useAuth();
+
+  if (loading) {
+    return <div>로딩 중...</div>;
+  }
+
+  if (!isAuthenticated) {
+    return <div>로그인이 필요합니다.</div>;
+  }
+
+  return (
+    <div>
+      <h1>안녕하세요, {user?.name}님!</h1>
+      <p>이메일: {user?.email}</p>
+    </div>
+  );
+};
+```
+
+### 2. 인증이 필요한 페이지 보호하기
+
+```tsx
+'use client';
+
+import { useAuth } from '@/contexts/AuthContext';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+const ProtectedPage = () => {
+  const { isAuthenticated, loading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!loading && !isAuthenticated) {
+      router.push('/login');
+    }
+  }, [isAuthenticated, loading, router]);
+
+  if (loading || !isAuthenticated) {
+    return <div>로딩 중...</div>;
+  }
+
+  return <div>보호된 페이지 내용</div>;
+};
+```
+
+### 3. 로그인 처리
+
+```tsx
+'use client';
+
+import { useAuth } from '@/contexts/AuthContext';
+
+const LoginPage = () => {
+  const { login } = useAuth();
+
+  const handleLogin = async (credentials) => {
+    try {
+      const response = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(credentials),
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        
+        // AuthContext에 사용자 정보 저장
+        login({
+          id: data.memberInfo.id,
+          email: data.memberInfo.email,
+          name: data.memberInfo.name,
+        });
+      }
+    } catch (error) {
+      console.error('로그인 실패:', error);
+    }
+  };
+
+  return (
+    // 로그인 폼
+  );
+};
+```
+
+### 4. 로그아웃 처리
+
+```tsx
+'use client';
+
+import { useAuth } from '@/contexts/AuthContext';
+
+const LogoutButton = () => {
+  const { logout } = useAuth();
+
+  const handleLogout = () => {
+    logout();
+    // 필요한 경우 홈페이지로 리다이렉트
+    window.location.href = '/';
+  };
+
+  return <button onClick={handleLogout}>로그아웃</button>;
+};
+```
+
+## AuthContext API
+
+### useAuth() 훅이 제공하는 값들
+
+- `user`: 사용자 정보 객체 (null이면 로그인되지 않음)
+- `isAuthenticated`: 로그인 상태 (boolean)
+- `login(userData)`: 로그인 함수
+- `logout()`: 로그아웃 함수
+- `loading`: 초기 로딩 상태 (boolean)
+
+### User 객체 구조
+
+```tsx
+interface User {
+  id: string;
+  email: string;
+  name: string;
+  // 필요한 다른 사용자 정보들
+}
+```
+
+## 파일 구조
+
+```
+src/
+├── contexts/
+│   └── AuthContext.tsx          # 인증 컨텍스트
+├── components/
+│   ├── Header.tsx               # 동적 헤더 컴포넌트
+│   └── UserInfoExample.tsx      # 사용자 정보 사용 예제
+└── app/
+    ├── layout.tsx               # AuthProvider 래핑
+    ├── login/page.tsx           # 로그인 페이지
+    ├── mypage/page.tsx          # 마이페이지 (인증 필요)
+    └── page.tsx                 # 홈페이지 (개인화된 환영 메시지)
+```
+
+## 주의사항
+
+1. **클라이언트 컴포넌트**: `useAuth()` 훅은 클라이언트 컴포넌트에서만 사용할 수 있습니다.
+2. **로딩 상태**: 초기 로딩 중에는 `loading` 상태를 확인하여 적절한 UI를 표시하세요.
+3. **인증 확인**: 보호된 페이지에서는 `isAuthenticated` 상태를 확인하여 리다이렉트를 처리하세요.
+4. **쿠키 관리**: 사용자 정보는 쿠키에 저장되므로 브라우저 설정에 따라 동작이 달라질 수 있습니다.
+
+## 예제 시나리오
+
+1. **사용자가 로그인하지 않은 상태**
+   - 헤더에 "로그인", "회원가입" 메뉴 표시
+   - 마이페이지 접근 시 로그인 페이지로 리다이렉트
+   - 홈페이지에 일반적인 환영 메시지 표시
+
+2. **사용자가 로그인한 상태**
+   - 헤더에 "채팅", "마이페이지", "로그아웃" 메뉴 표시
+   - 마이페이지에서 실제 사용자 정보 표시
+   - 홈페이지에 개인화된 환영 메시지 표시
+   - 모든 페이지에서 사용자 정보 접근 가능 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@types/js-cookie": "^3.0.6",
+        "js-cookie": "^3.0.5",
         "next": "15.4.5",
         "react": "19.1.0",
         "react-dom": "19.1.0"
@@ -1281,6 +1283,12 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/js-cookie": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
+      "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==",
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -4101,6 +4109,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -9,19 +9,21 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@types/js-cookie": "^3.0.6",
+    "js-cookie": "^3.0.5",
+    "next": "15.4.5",
     "react": "19.1.0",
-    "react-dom": "19.1.0",
-    "next": "15.4.5"
+    "react-dom": "19.1.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.4.5",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
+import { AuthProvider } from "@/contexts/AuthContext";
+import Header from "@/components/Header";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -17,48 +19,10 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body className={inter.className}>
-        <div className="min-h-screen bg-gradient-to-b from-[#2a4fa2] via-[#1a365d] to-[#1a365d]">
-          {/* Header */}
-          <header className="bg-[#1a365d] px-6 py-4">
-            <div className="max-w-7xl mx-auto flex justify-between items-center">
-              <div className="text-white text-xl font-bold">PatentMarket</div>
-              <nav className="flex gap-6 text-white">
-                <a href="/" className="hover:text-gray-300 transition-colors">
-                  홈
-                </a>
-                <a
-                  href="/patents"
-                  className="hover:text-gray-300 transition-colors"
-                >
-                  특허목록
-                </a>
-                <a
-                  href="/mypage"
-                  className="hover:text-gray-300 transition-colors"
-                >
-                  마이페이지
-                </a>
-                <a
-                  href="/login"
-                  className="hover:text-gray-300 transition-colors"
-                >
-                  로그인
-                </a>
-                <a
-                  href="/register"
-                  className="hover:text-gray-300 transition-colors"
-                >
-                  회원가입
-                </a>
-                <a
-                  href="/chat"
-                  className="hover:text-gray-300 transition-colors"
-                >
-                  채팅
-                </a>
-              </nav>
-            </div>
-          </header>
+        <AuthProvider>
+          <div className="min-h-screen bg-gradient-to-b from-[#2a4fa2] via-[#1a365d] to-[#1a365d]">
+            {/* Header */}
+            <Header />
 
           {/* Main Content */}
           <main>{children}</main>
@@ -178,6 +142,7 @@ export default function RootLayout({
             </button>
           </div>
         </div>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -2,9 +2,11 @@
 
 import React, { useState } from "react";
 import { useRouter } from "next/navigation";
+import { useAuth } from "@/contexts/AuthContext";
 
 export default function LoginPage() {
   const router = useRouter();
+  const { login } = useAuth();
   const [formData, setFormData] = useState({
     email: "",
     password: "",
@@ -51,9 +53,13 @@ export default function LoginPage() {
           // AccessToken만 localStorage에 저장 (보안상 RefreshToken은 서버에서 관리)
           localStorage.setItem('accessToken', accessToken);
           
-          // 사용자 정보 저장
+          // AuthContext에 사용자 정보 저장
           if (memberInfo) {
-            localStorage.setItem('userInfo', JSON.stringify(memberInfo));
+            login({
+              id: memberInfo.id || memberInfo.memberId,
+              email: memberInfo.email,
+              name: memberInfo.name || memberInfo.nickname,
+            });
           }
           
           // 로그인 성공 시 메인 페이지로 리다이렉트

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,6 +1,39 @@
+'use client';
+
 import React from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 
 export default function MyPage() {
+  const { user, isAuthenticated, loading } = useAuth();
+  const router = useRouter();
+
+  // 로그인하지 않은 사용자는 로그인 페이지로 리다이렉트
+  useEffect(() => {
+    if (!loading && !isAuthenticated) {
+      router.push('/login');
+    }
+  }, [isAuthenticated, loading, router]);
+
+  // 로딩 중이거나 인증되지 않은 경우 로딩 표시
+  if (loading || !isAuthenticated) {
+    return (
+      <div className="pb-10">
+        <section className="px-6 py-8">
+          <div className="max-w-7xl mx-auto">
+            <div className="bg-white/95 backdrop-blur-sm rounded-2xl p-6 shadow-xl">
+              <div className="text-center">
+                <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-600 mx-auto"></div>
+                <p className="mt-4 text-gray-600">로딩 중...</p>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    );
+  }
+
   return (
     <div className="pb-10">
       <section className="px-6 py-8">
@@ -14,8 +47,8 @@ export default function MyPage() {
                 <span className="text-purple-600 text-xl">👤</span>
               </div>
               <div>
-                <h2 className="text-lg font-bold text-[#1a365d]">김사용자</h2>
-                <p className="text-gray-600 text-sm">kim@example.com</p>
+                <h2 className="text-lg font-bold text-[#1a365d]">{user?.name || '사용자'}</h2>
+                <p className="text-gray-600 text-sm">{user?.email || '이메일 없음'}</p>
               </div>
             </div>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-center">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,11 @@
+'use client';
+
 import Image from "next/image";
+import { useAuth } from "@/contexts/AuthContext";
 
 export default function Home() {
+  const { user, isAuthenticated } = useAuth();
+
   return (
     <>
       {/* Hero Section */}
@@ -8,7 +13,28 @@ export default function Home() {
         <div className="max-w-7xl mx-auto">
           <div className="bg-white/95 backdrop-blur-sm rounded-2xl p-10 text-center max-w-5xl mx-auto shadow-xl">
             <h1 className="text-3xl font-bold text-[#1a365d] mb-4">특허 거래의 새로운 경험</h1>
-            <p className="text-base text-[#1a365d] leading-relaxed">혁신적인 특허와 무형자산을 안전하고 편리하게 거래하세요. 전문가들이 인증한 고품질 특허만을 제공합니다.</p>
+            <p className="text-base text-[#1a365d] leading-relaxed">
+              {isAuthenticated 
+                ? `${user?.name}님을 위한 맞춤 특허를 찾아보세요.` 
+                : '혁신적인 특허와 무형자산을 안전하고 편리하게 거래하세요. 전문가들이 인증한 고품질 특허만을 제공합니다.'
+              }
+            </p>
+            {!isAuthenticated && (
+              <div className="mt-6">
+                <a 
+                  href="/login" 
+                  className="bg-purple-600 hover:bg-purple-700 text-white px-6 py-3 rounded-lg transition-colors font-medium mr-4"
+                >
+                  로그인
+                </a>
+                <a 
+                  href="/register" 
+                  className="bg-transparent border-2 border-purple-600 text-purple-600 hover:bg-purple-600 hover:text-white px-6 py-3 rounded-lg transition-colors font-medium"
+                >
+                  회원가입
+                </a>
+              </div>
+            )}
           </div>
         </div>
       </section>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,14 +2,24 @@
 
 import { useAuth } from '@/contexts/AuthContext';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
 const Header = () => {
   const { isAuthenticated, user, logout } = useAuth();
+  const router = useRouter();
 
   const handleLogout = async () => {
-    await logout();
-    // 로그아웃 후 홈페이지로 리다이렉트
-    window.location.href = '/';
+    
+    try {
+      await logout();
+      // 로그아웃 후 홈페이지로 리다이렉트
+      router.push('/');
+    } catch (error) {
+      // 로그아웃 실패 시 에러 메시지 출력
+      console.error('로그아웃 실패:', error);
+      // 에러가 발생해도 홈페이지로 리다이렉트
+      router.push('/');
+    }
   };
 
   return (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useAuth } from '@/contexts/AuthContext';
+import Link from 'next/link';
+
+const Header = () => {
+  const { isAuthenticated, user, logout } = useAuth();
+
+  const handleLogout = async () => {
+    await logout();
+    // 로그아웃 후 홈페이지로 리다이렉트
+    window.location.href = '/';
+  };
+
+  return (
+    <header className="bg-[#1a365d] px-6 py-4">
+      <div className="max-w-7xl mx-auto flex justify-between items-center">
+        <div className="text-white text-xl font-bold">
+          <Link href="/">PatentMarket</Link>
+        </div>
+        
+        <nav className="flex gap-6 text-white">
+          <Link href="/" className="hover:text-gray-300 transition-colors">
+            홈
+          </Link>
+          <Link href="/patents" className="hover:text-gray-300 transition-colors">
+            특허목록
+          </Link>
+          
+          {isAuthenticated ? (
+            // 로그인 후 메뉴
+            <>
+              <Link href="/chat" className="hover:text-gray-300 transition-colors">
+                채팅
+              </Link>
+              <Link href="/mypage" className="hover:text-gray-300 transition-colors">
+                마이페이지
+              </Link>
+              <button
+                onClick={handleLogout}
+                className="hover:text-gray-300 transition-colors cursor-pointer"
+              >
+                로그아웃
+              </button>
+            </>
+          ) : (
+            // 로그인 전 메뉴
+            <>
+              <Link href="/login" className="hover:text-gray-300 transition-colors">
+                로그인
+              </Link>
+              <Link href="/register" className="hover:text-gray-300 transition-colors">
+                회원가입
+              </Link>
+            </>
+          )}
+        </nav>
+      </div>
+    </header>
+  );
+};
+
+export default Header; 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import Cookies from 'js-cookie';
+
+interface User {
+  id: string;
+  email: string;
+  name: string;
+  // 필요한 다른 사용자 정보들
+}
+
+interface AuthContextType {
+  user: User | null;
+  isAuthenticated: boolean;
+  login: (userData: User) => void;
+  logout: () => void;
+  loading: boolean;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (context === undefined) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};
+
+interface AuthProviderProps {
+  children: ReactNode;
+}
+
+export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    // 페이지 로드 시 쿠키에서 사용자 정보 확인
+    const userCookie = Cookies.get('user');
+    if (userCookie) {
+      try {
+        const userData = JSON.parse(userCookie);
+        setUser(userData);
+      } catch (error) {
+        console.error('Failed to parse user cookie:', error);
+        Cookies.remove('user');
+      }
+    }
+    setLoading(false);
+  }, []);
+
+  const login = (userData: User) => {
+    setUser(userData);
+    // 쿠키에 사용자 정보 저장 (7일간 유효)
+    Cookies.set('user', JSON.stringify(userData), { expires: 7 });
+  };
+
+  const logout = async () => {
+    try {
+      // Backend에 로그아웃 요청을 보내서 refreshToken을 null로 업데이트
+      const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8080';
+      const accessToken = localStorage.getItem('accessToken');
+      
+      if (accessToken) {
+        await fetch(`${backendUrl}/api/auth/logout`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${accessToken}`,
+          },
+        });
+      }
+    } catch (error) {
+      console.error('Logout API call failed:', error);
+    } finally {
+      // 로컬 상태 정리
+      setUser(null);
+      // 쿠키에서 사용자 정보 제거
+      Cookies.remove('user');
+      // localStorage에서 토큰 제거
+      localStorage.removeItem('accessToken');
+    }
+  };
+
+  const value: AuthContextType = {
+    user,
+    isAuthenticated: !!user,
+    login,
+    logout,
+    loading,
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}; 


### PR DESCRIPTION
1. 기존의 layout.tsx에서 헤더 부분을 분리하려 로그인 여부에 맞게 구현
2. 김에 로그아웃 기능 구현
3. **USER_AUTH_GUIDE.md**  로그인한 사용자 정보 사용 방법 생성
=> 가이드 파일에서 1번과 2번 항목을 참고하면 사용 가능

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 전역 사용자 인증 상태 관리를 위한 인증 컨텍스트 도입 및 로그인 상태에 따라 동적으로 변경되는 헤더 메뉴 제공
  * 인증된 사용자만 접근 가능한 마이페이지 및 인증 상태에 따라 맞춤형 홈 화면 메시지 표시
  * 로그인/로그아웃 시 사용자 정보 및 인증 상태가 쿠키로 7일간 유지되어 새로고침 후에도 로그인 상태가 지속됨
  * 로그아웃 시 비동기 처리 및 오류 로그 기록 후 홈으로 리다이렉트 기능 추가

* **문서화**
  * 사용자 인증 시스템 사용법 및 주요 기능에 대한 가이드 문서 추가

* **패키지 관리**
  * 인증 관련 쿠키 관리를 위해 js-cookie 라이브러리 및 타입 추가

* **리팩토링**
  * 레이아웃 구조를 개선하여 헤더를 별도 컴포넌트로 분리하고 인증 컨텍스트로 전체 앱을 감쌈
  * 로그인 페이지 및 마이페이지에 인증 컨텍스트 통합 및 인증 상태에 따른 UI/동작 변경

* **버그 수정**
  * 인증되지 않은 사용자가 마이페이지 접근 시 자동으로 로그인 페이지로 리다이렉트되도록 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->