### PR TITLE
[refactor] 쿠키 방식 로그인으로 변경

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -11,7 +11,6 @@ export default function LoginPage() {
   const [formData, setFormData] = useState({
     email: "",
     password: "",
-    rememberMe: false,
   });
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
@@ -36,10 +35,10 @@ export default function LoginPage() {
   }
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, value, type, checked } = e.target;
+    const { name, value } = e.target;
     setFormData(prev => ({
       ...prev,
-      [name]: type === "checkbox" ? checked : value,
+      [name]: value,
     }));
   };
 
@@ -57,16 +56,13 @@ export default function LoginPage() {
       if (response.data.data) {
         const { accessToken, refreshToken, memberInfo } = response.data.data;
         
-        // AccessToken만 localStorage에 저장 (보안상 RefreshToken은 서버에서 관리)
-        localStorage.setItem('accessToken', accessToken);
-        
-        // AuthContext에 사용자 정보 저장
+        // AuthContext에 사용자 정보 저장 (쿠키에 자동으로 토큰이 저장됨)
         if (memberInfo) {
           login({
             id: memberInfo.id.toString(),
             email: memberInfo.email,
             name: memberInfo.name,
-          }, accessToken);
+          }, accessToken, refreshToken);
         }
         
         // 로그인 성공 시 메인 페이지로 리다이렉트
@@ -134,17 +130,7 @@ export default function LoginPage() {
                 />
               </div>
               
-              <div className="flex items-center justify-between">
-                <label className="flex items-center">
-                  <input 
-                    type="checkbox" 
-                    name="rememberMe"
-                    checked={formData.rememberMe}
-                    onChange={handleInputChange}
-                    className="rounded border-gray-300 text-purple-600 focus:ring-purple-500" 
-                  />
-                  <span className="ml-2 text-sm text-gray-600">로그인 상태 유지</span>
-                </label>
+              <div className="flex items-center justify-end">
                 <a href="#" className="text-sm text-purple-600 hover:text-purple-700">
                   비밀번호 찾기
                 </a>

--- a/src/utils/cookieUtils.ts
+++ b/src/utils/cookieUtils.ts
@@ -1,0 +1,56 @@
+// 쿠키 관리를 위한 유틸리티 함수들 (AccessToken과 RefreshToken)
+
+// 쿠키 설정
+export const setCookie = (name: string, value: string, days: number = 7) => {
+  const expires = new Date();
+  expires.setTime(expires.getTime() + days * 24 * 60 * 60 * 1000);
+  const cookieValue = `${name}=${value};expires=${expires.toUTCString()};path=/;SameSite=Strict`;
+  document.cookie = cookieValue;
+};
+
+// 쿠키 가져오기
+export const getCookie = (name: string): string | null => {
+  const nameEQ = name + "=";
+  const ca = document.cookie.split(';');
+  for (let i = 0; i < ca.length; i++) {
+    let c = ca[i];
+    while (c.charAt(0) === ' ') c = c.substring(1, c.length);
+    if (c.indexOf(nameEQ) === 0) return c.substring(nameEQ.length, c.length);
+  }
+  return null;
+};
+
+// 쿠키 삭제
+export const deleteCookie = (name: string) => {
+  document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/;`;
+};
+
+// AccessToken 쿠키 설정
+export const setAccessTokenCookie = (token: string) => {
+  setCookie('accessToken', token, 1); // 1일
+};
+
+// AccessToken 쿠키 가져오기
+export const getAccessTokenCookie = (): string | null => {
+  return getCookie('accessToken');
+};
+
+// AccessToken 쿠키 삭제
+export const clearAccessTokenCookie = () => {
+  deleteCookie('accessToken');
+};
+
+// RefreshToken 쿠키 설정
+export const setRefreshTokenCookie = (token: string) => {
+  setCookie('refreshToken', token, 7); // 7일
+};
+
+// RefreshToken 쿠키 가져오기
+export const getRefreshTokenCookie = (): string | null => {
+  return getCookie('refreshToken');
+};
+
+// RefreshToken 쿠키 삭제
+export const clearRefreshTokenCookie = () => {
+  deleteCookie('refreshToken');
+}; 


### PR DESCRIPTION
1. 쿠키 방식으로 로그인 변경

==사용법==
const response = await apiClient.get('/api/v1/posts/1');

이런식으로 바로 헤더 없이도 바로 api 호출 가능, 로그인 시, 토큰이 들어가기 때문
