### PR TITLE
[feat] 마이페이지 거래 내역, 상세 거래 내역 구현

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,13 +1,16 @@
 'use client';
 
-import React from "react";
+import React, { useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
+import TradeHistory from "@/components/trade/TradeHistory";
+import TradeDetail from "@/components/trade/TradeDetail";
 
 export default function MyPage() {
   const { user, isAuthenticated, loading, refreshUserInfo } = useAuth();
   const router = useRouter();
+  const [selectedTradeId, setSelectedTradeId] = useState<number | null>(null);
 
   // 로그인하지 않은 사용자는 로그인 페이지로 리다이렉트
   useEffect(() => {
@@ -133,53 +136,58 @@ export default function MyPage() {
             </div>
           </div>
           
-                     {/* Liked Patents Section */}
-           <div className="bg-white/95 backdrop-blur-sm rounded-2xl p-6 shadow-xl relative">
-             <h3 className="text-lg font-bold text-[#1a365d] mb-4">찜한 특허</h3>
-             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-               {/* Liked Patent Card 1 */}
-               <div className="border border-gray-200 rounded-xl p-4 bg-white/50">
-                 <div className="bg-pink-100 rounded-full w-10 h-10 flex items-center justify-center mb-3">
-                   <span className="text-pink-600 text-lg">🔊</span>
-                 </div>
-                 <h4 className="font-bold text-[#1a365d] mb-2 text-sm">AI 기반 음성인식 알고리즘</h4>
-                 <p className="text-gray-600 text-xs mb-3">혁신적인 음성인식 기술</p>
-                 <div className="flex justify-between items-center mb-2">
-                   <span className="font-bold text-base text-[#1a365d]">₩15,000,000</span>
-                   <span className="bg-green-100 text-green-800 px-2 py-1 rounded-full text-xs">판매중</span>
-                 </div>
-                 <div className="flex gap-2">
-                   <button className="text-purple-600 hover:text-purple-700 text-sm">구매문의</button>
-                   <button className="text-red-600 hover:text-red-700 text-sm">찜해제</button>
-                 </div>
-               </div>
-               
-               {/* Liked Patent Card 2 */}
-               <div className="border border-gray-200 rounded-xl p-4 bg-white/50">
-                 <div className="bg-purple-100 rounded-full w-10 h-10 flex items-center justify-center mb-3">
-                   <span className="text-purple-600 text-lg">🌱</span>
-                 </div>
-                 <h4 className="font-bold text-[#1a365d] mb-2 text-sm">친환경 플라스틱 대체 기술</h4>
-                 <p className="text-gray-600 text-xs mb-3">생분해성 소재 기술</p>
-                 <div className="flex justify-between items-center mb-2">
-                   <span className="font-bold text-base text-[#1a365d]">₩12,000,000</span>
-                   <span className="bg-green-100 text-green-800 px-2 py-1 rounded-full text-xs">판매중</span>
-                 </div>
-                 <div className="flex gap-2">
-                   <button className="text-purple-600 hover:text-purple-700 text-sm">구매문의</button>
-                   <button className="text-red-600 hover:text-red-700 text-sm">찜해제</button>
-                 </div>
-               </div>
-             </div>
-             
-             
-           </div>
+          {/* Liked Patents Section */}
+          <div className="bg-white/95 backdrop-blur-sm rounded-2xl p-6 mb-6 shadow-xl">
+            <h3 className="text-lg font-bold text-[#1a365d] mb-4">찜한 특허</h3>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+              {/* Liked Patent Card 1 */}
+              <div className="border border-gray-200 rounded-xl p-4 bg-white/50">
+                <div className="bg-pink-100 rounded-full w-10 h-10 flex items-center justify-center mb-3">
+                  <span className="text-pink-600 text-lg">🔊</span>
+                </div>
+                <h4 className="font-bold text-[#1a365d] mb-2 text-sm">AI 기반 음성인식 알고리즘</h4>
+                <p className="text-gray-600 text-xs mb-3">혁신적인 음성인식 기술</p>
+                <div className="flex justify-between items-center mb-2">
+                  <span className="font-bold text-base text-[#1a365d]">₩15,000,000</span>
+                  <span className="bg-green-100 text-green-800 px-2 py-1 rounded-full text-xs">판매중</span>
+                </div>
+                <div className="flex gap-2">
+                  <button className="text-purple-600 hover:text-purple-700 text-sm">구매문의</button>
+                  <button className="text-red-600 hover:text-red-700 text-sm">찜해제</button>
+                </div>
+              </div>
+              
+              {/* Liked Patent Card 2 */}
+              <div className="border border-gray-200 rounded-xl p-4 bg-white/50">
+                <div className="bg-purple-100 rounded-full w-10 h-10 flex items-center justify-center mb-3">
+                  <span className="text-purple-600 text-lg">🌱</span>
+                </div>
+                <h4 className="font-bold text-[#1a365d] mb-2 text-sm">친환경 플라스틱 대체 기술</h4>
+                <p className="text-gray-600 text-xs mb-3">생분해성 소재 기술</p>
+                <div className="flex justify-between items-center mb-2">
+                  <span className="font-bold text-base text-[#1a365d]">₩12,000,000</span>
+                  <span className="bg-green-100 text-green-800 px-2 py-1 rounded-full text-xs">판매중</span>
+                </div>
+                <div className="flex gap-2">
+                  <button className="text-purple-600 hover:text-purple-700 text-sm">구매문의</button>
+                  <button className="text-red-600 hover:text-red-700 text-sm">찜해제</button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Trade History Section */}
+          <TradeHistory onTradeSelect={setSelectedTradeId} />
         </div>
       </section>
 
-      
-
-      
+      {/* Trade Detail Modal */}
+      {selectedTradeId && (
+        <TradeDetail 
+          tradeId={selectedTradeId} 
+          onClose={() => setSelectedTradeId(null)} 
+        />
+      )}
     </div>
   );
 }

--- a/src/components/TradeList.tsx
+++ b/src/components/TradeList.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import React, { useState, useEffect } from "react";
+import { tradeAPI, postAPI, userAPI, Trade, PostDetail, UserInfo } from "@/utils/apiClient";
+
+interface TradeListProps {
+  onTradeSelect: (trade: Trade) => void;
+}
+
+export default function TradeList({ onTradeSelect }: TradeListProps) {
+  const [trades, setTrades] = useState<Trade[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [tradeDetails, setTradeDetails] = useState<{[key: number]: {post: PostDetail, seller: UserInfo, buyer: UserInfo}}>({});
+
+  useEffect(() => {
+    fetchTrades();
+  }, []);
+
+  const fetchTrades = async () => {
+    setLoading(true);
+    try {
+      const response = await tradeAPI.getMyTrades(0, 20);
+      setTrades(response.data.content);
+      
+      // 각 거래에 대한 상세 정보 가져오기
+      const details: {[key: number]: {post: PostDetail, seller: UserInfo, buyer: UserInfo}} = {};
+      
+      for (const trade of response.data.content) {
+        try {
+          const [postResponse, sellerResponse, buyerResponse] = await Promise.all([
+            postAPI.getPostDetail(trade.postId),
+            userAPI.getUserInfo(trade.sellerId),
+            userAPI.getUserInfo(trade.buyerId)
+          ]);
+          
+          details[trade.id] = {
+            post: postResponse.data,
+            seller: sellerResponse.data,
+            buyer: buyerResponse.data
+          };
+        } catch (error) {
+          console.error(`거래 ${trade.id} 상세 정보 조회 실패:`, error);
+        }
+      }
+      
+      setTradeDetails(details);
+    } catch (error) {
+      console.error('거래 내역 조회 실패:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="bg-white/95 backdrop-blur-sm rounded-2xl p-6 shadow-xl">
+        <div className="text-center py-8">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-purple-600 mx-auto"></div>
+          <p className="mt-2 text-gray-600">거래 내역을 불러오는 중...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white/95 backdrop-blur-sm rounded-2xl p-6 shadow-xl">
+      <h3 className="text-lg font-bold text-[#1a365d] mb-4">거래 내역</h3>
+      
+      {trades.length > 0 ? (
+        <div className="space-y-4">
+          {trades.map((trade) => {
+            const detail = tradeDetails[trade.id];
+            return (
+              <div 
+                key={trade.id} 
+                className="border border-gray-200 rounded-xl p-4 bg-white/50 cursor-pointer hover:bg-gray-50 transition-colors"
+                onClick={() => onTradeSelect(trade)}
+              >
+                <div className="flex justify-between items-start mb-3">
+                  <div>
+                    <h4 className="font-bold text-[#1a365d] text-sm">
+                      {detail?.post?.title || `게시글 ${trade.postId}`}
+                    </h4>
+                    <p className="text-gray-600 text-xs">
+                      판매자: {detail?.seller?.name || `사용자 ${trade.sellerId}`}
+                    </p>
+                  </div>
+                  <span className={`px-2 py-1 rounded-full text-xs ${
+                    trade.status === 'COMPLETED' 
+                      ? 'bg-green-100 text-green-800' 
+                      : 'bg-yellow-100 text-yellow-800'
+                  }`}>
+                    {trade.status === 'COMPLETED' ? '구매완료' : trade.status}
+                  </span>
+                </div>
+                <div className="flex justify-between items-center">
+                  <span className="font-bold text-base text-[#1a365d]">
+                    ₩{trade.price.toLocaleString()}
+                  </span>
+                  <span className="text-gray-500 text-xs">
+                    {new Date(trade.createdAt).toLocaleDateString()}
+                  </span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="text-center py-8">
+          <div className="text-gray-400 text-4xl mb-2">📦</div>
+          <p className="text-gray-600">거래 내역이 없습니다.</p>
+          <p className="text-gray-500 text-sm mt-1">특허를 구매해보세요!</p>
+        </div>
+      )}
+    </div>
+  );
+} 

--- a/src/components/TransactionDetail.tsx
+++ b/src/components/TransactionDetail.tsx
@@ -1,0 +1,298 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { transactionAPI, TransactionDetail as TransactionDetailType } from '@/utils/apiClient';
+import { useAuth } from '@/contexts/AuthContext';
+
+interface TransactionDetailProps {
+  transactionId: string;
+  onBack: () => void;
+}
+
+const TransactionDetail: React.FC<TransactionDetailProps> = ({ transactionId, onBack }) => {
+  const { user } = useAuth();
+  const [transaction, setTransaction] = useState<TransactionDetailType | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<'overview' | 'documents' | 'messages' | 'payments'>('overview');
+
+  const fetchTransactionDetail = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const detail = await transactionAPI.getTransactionDetail(transactionId);
+      setTransaction(detail);
+    } catch (err) {
+      setError('거래 상세 정보를 불러오는데 실패했습니다.');
+      console.error('Failed to fetch transaction detail:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchTransactionDetail();
+  }, [transactionId]);
+
+  const formatPrice = (price: number) => {
+    return new Intl.NumberFormat('ko-KR').format(price);
+  };
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString('ko-KR', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  const getStatusLabel = (status: string) => {
+    const statusMap = {
+      'PENDING': '대기중',
+      'IN_PROGRESS': '진행중',
+      'COMPLETED': '완료',
+      'CANCELLED': '취소',
+    };
+    return statusMap[status as keyof typeof statusMap] || status;
+  };
+
+  const getStatusColor = (status: string) => {
+    const colorMap = {
+      'PENDING': 'bg-yellow-100 text-yellow-800',
+      'IN_PROGRESS': 'bg-blue-100 text-blue-800',
+      'COMPLETED': 'bg-green-100 text-green-800',
+      'CANCELLED': 'bg-red-100 text-red-800',
+    };
+    return colorMap[status as keyof typeof colorMap] || 'bg-gray-100 text-gray-800';
+  };
+
+  const getDocumentTypeLabel = (type: string) => {
+    const typeMap = {
+      'CONTRACT': '계약서',
+      'PATENT_DOCUMENT': '특허 문서',
+      'PAYMENT_PROOF': '결제 증빙',
+      'OTHER': '기타',
+    };
+    return typeMap[type as keyof typeof typeMap] || type;
+  };
+
+  if (loading) {
+    return (
+      <div className="bg-white/95 backdrop-blur-sm rounded-2xl p-6 shadow-xl">
+        <div className="text-center py-8">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-purple-600 mx-auto"></div>
+          <p className="mt-2 text-gray-600">거래 상세 정보를 불러오는 중...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !transaction) {
+    return (
+      <div className="bg-white/95 backdrop-blur-sm rounded-2xl p-6 shadow-xl">
+        <div className="text-center text-red-600">
+          <p>{error || '거래 정보를 찾을 수 없습니다.'}</p>
+          <button 
+            onClick={onBack}
+            className="mt-2 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700"
+          >
+            목록으로 돌아가기
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white/95 backdrop-blur-sm rounded-2xl p-6 shadow-xl">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <button
+          onClick={onBack}
+          className="flex items-center gap-2 text-purple-600 hover:text-purple-700"
+        >
+          <span>←</span>
+          <span>목록으로</span>
+        </button>
+        <span className={`px-3 py-1 rounded-full text-xs font-medium ${getStatusColor(transaction.status)}`}>
+          {getStatusLabel(transaction.status)}
+        </span>
+      </div>
+
+      {/* Transaction Info */}
+      <div className="border-b border-gray-200 pb-6 mb-6">
+        <div className="flex items-center gap-4 mb-4">
+          <div className="bg-gray-100 rounded-full w-16 h-16 flex items-center justify-center">
+            <span className="text-2xl">{transaction.patentIcon}</span>
+          </div>
+          <div>
+            <h2 className="text-xl font-bold text-[#1a365d] mb-2">{transaction.patentTitle}</h2>
+            <p className="text-gray-600 text-sm">
+              거래 금액: <span className="font-bold text-[#1a365d]">₩{formatPrice(transaction.price)}</span>
+            </p>
+          </div>
+        </div>
+        
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+          <div>
+            <p className="text-gray-600 mb-1">거래 유형</p>
+            <p className="font-medium">{transaction.buyerId === user?.id ? '구매' : '판매'}</p>
+          </div>
+          <div>
+            <p className="text-gray-600 mb-1">거래 상대</p>
+            <p className="font-medium">
+              {transaction.buyerId === user?.id ? transaction.sellerName : transaction.buyerName}
+            </p>
+          </div>
+          <div>
+            <p className="text-gray-600 mb-1">거래 시작일</p>
+            <p className="font-medium">{formatDate(transaction.createdAt)}</p>
+          </div>
+          <div>
+            <p className="text-gray-600 mb-1">최종 업데이트</p>
+            <p className="font-medium">{formatDate(transaction.updatedAt)}</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="border-b border-gray-200 mb-6">
+        <div className="flex gap-6">
+          {[
+            { id: 'overview', label: '개요', icon: '📋' },
+            { id: 'documents', label: '문서', icon: '📄' },
+            { id: 'messages', label: '메시지', icon: '💬' },
+            { id: 'payments', label: '결제', icon: '💰' },
+          ].map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id as any)}
+              className={`flex items-center gap-2 px-4 py-2 border-b-2 font-medium transition-colors ${
+                activeTab === tab.id
+                  ? 'border-purple-600 text-purple-600'
+                  : 'border-transparent text-gray-600 hover:text-gray-800'
+              }`}
+            >
+              <span>{tab.icon}</span>
+              <span>{tab.label}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Tab Content */}
+      <div className="min-h-[400px]">
+        {activeTab === 'overview' && (
+          <div>
+            <h3 className="text-lg font-bold text-[#1a365d] mb-4">거래 개요</h3>
+            <div className="bg-gray-50 rounded-lg p-4">
+              <p className="text-gray-700 leading-relaxed">{transaction.description}</p>
+            </div>
+          </div>
+        )}
+
+        {activeTab === 'documents' && (
+          <div>
+            <h3 className="text-lg font-bold text-[#1a365d] mb-4">관련 문서</h3>
+            {transaction.documents.length === 0 ? (
+              <div className="text-center py-8 text-gray-500">
+                <div className="text-4xl mb-2">📄</div>
+                <p>등록된 문서가 없습니다.</p>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {transaction.documents.map((doc) => (
+                  <div key={doc.id} className="border border-gray-200 rounded-lg p-4 flex items-center justify-between">
+                    <div className="flex items-center gap-3">
+                      <div className="bg-blue-100 rounded-full w-10 h-10 flex items-center justify-center">
+                        <span className="text-blue-600">📄</span>
+                      </div>
+                      <div>
+                        <p className="font-medium text-[#1a365d]">{doc.name}</p>
+                        <p className="text-sm text-gray-600">
+                          {getDocumentTypeLabel(doc.type)} • {formatDate(doc.uploadedAt)}
+                        </p>
+                      </div>
+                    </div>
+                    <a
+                      href={doc.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 text-sm"
+                    >
+                      다운로드
+                    </a>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {activeTab === 'messages' && (
+          <div>
+            <h3 className="text-lg font-bold text-[#1a365d] mb-4">거래 메시지</h3>
+            {transaction.messages.length === 0 ? (
+              <div className="text-center py-8 text-gray-500">
+                <div className="text-4xl mb-2">💬</div>
+                <p>거래 관련 메시지가 없습니다.</p>
+              </div>
+            ) : (
+              <div className="space-y-4">
+                {transaction.messages.map((message) => (
+                  <div key={message.id} className="border border-gray-200 rounded-lg p-4">
+                    <div className="flex items-center justify-between mb-2">
+                      <span className="font-medium text-[#1a365d]">{message.senderName}</span>
+                      <span className="text-sm text-gray-500">{formatDate(message.createdAt)}</span>
+                    </div>
+                    <p className="text-gray-700">{message.content}</p>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {activeTab === 'payments' && (
+          <div>
+            <h3 className="text-lg font-bold text-[#1a365d] mb-4">결제 내역</h3>
+            {transaction.paymentHistory.length === 0 ? (
+              <div className="text-center py-8 text-gray-500">
+                <div className="text-4xl mb-2">💰</div>
+                <p>결제 내역이 없습니다.</p>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {transaction.paymentHistory.map((payment) => (
+                  <div key={payment.id} className="border border-gray-200 rounded-lg p-4">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="font-medium text-[#1a365d]">₩{formatPrice(payment.amount)}</p>
+                        <p className="text-sm text-gray-600">{payment.method}</p>
+                      </div>
+                      <div className="text-right">
+                        <span className={`px-2 py-1 rounded-full text-xs font-medium ${
+                          payment.status === 'COMPLETED' ? 'bg-green-100 text-green-800' :
+                          payment.status === 'PENDING' ? 'bg-yellow-100 text-yellow-800' :
+                          'bg-red-100 text-red-800'
+                        }`}>
+                          {payment.status === 'COMPLETED' ? '완료' :
+                           payment.status === 'PENDING' ? '대기중' : '실패'}
+                        </span>
+                        <p className="text-sm text-gray-500 mt-1">{formatDate(payment.createdAt)}</p>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TransactionDetail; 

--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { transactionAPI, Transaction } from '@/utils/apiClient';
+import { useAuth } from '@/contexts/AuthContext';
+
+interface TransactionListProps {
+  onTransactionSelect: (transaction: Transaction) => void;
+}
+
+const TransactionList: React.FC<TransactionListProps> = ({ onTransactionSelect }) => {
+  const { user } = useAuth();
+  const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
+  const [selectedStatus, setSelectedStatus] = useState<string>('ALL');
+
+  const statusOptions = [
+    { value: 'ALL', label: '전체', color: 'bg-gray-100 text-gray-800' },
+    { value: 'PENDING', label: '대기중', color: 'bg-yellow-100 text-yellow-800' },
+    { value: 'IN_PROGRESS', label: '진행중', color: 'bg-blue-100 text-blue-800' },
+    { value: 'COMPLETED', label: '완료', color: 'bg-green-100 text-green-800' },
+    { value: 'CANCELLED', label: '취소', color: 'bg-red-100 text-red-800' },
+  ];
+
+  const getStatusLabel = (status: string) => {
+    const option = statusOptions.find(opt => opt.value === status);
+    return option?.label || status;
+  };
+
+  const getStatusColor = (status: string) => {
+    const option = statusOptions.find(opt => opt.value === status);
+    return option?.color || 'bg-gray-100 text-gray-800';
+  };
+
+  const fetchTransactions = async (page: number = 0, status: string = 'ALL') => {
+    try {
+      setLoading(true);
+      setError(null);
+      
+      const response = status === 'ALL' 
+        ? await transactionAPI.getTransactions(page, 10)
+        : await transactionAPI.getTransactionsByStatus(status, page, 10);
+      
+      if (page === 0) {
+        setTransactions(response.transactions);
+      } else {
+        setTransactions(prev => [...prev, ...response.transactions]);
+      }
+      
+      setHasMore(response.hasMore);
+      setCurrentPage(page);
+    } catch (err) {
+      setError('거래 내역을 불러오는데 실패했습니다.');
+      console.error('Failed to fetch transactions:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchTransactions(0, selectedStatus);
+  }, [selectedStatus]);
+
+  const handleStatusChange = (status: string) => {
+    setSelectedStatus(status);
+    setCurrentPage(0);
+  };
+
+  const handleLoadMore = () => {
+    if (!loading && hasMore) {
+      fetchTransactions(currentPage + 1, selectedStatus);
+    }
+  };
+
+  const formatPrice = (price: number) => {
+    return new Intl.NumberFormat('ko-KR').format(price);
+  };
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString('ko-KR', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+  };
+
+  if (error) {
+    return (
+      <div className="bg-white/95 backdrop-blur-sm rounded-2xl p-6 shadow-xl">
+        <div className="text-center text-red-600">
+          <p>{error}</p>
+          <button 
+            onClick={() => fetchTransactions(0, selectedStatus)}
+            className="mt-2 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700"
+          >
+            다시 시도
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white/95 backdrop-blur-sm rounded-2xl p-6 shadow-xl">
+      <div className="flex justify-between items-center mb-6">
+        <h3 className="text-lg font-bold text-[#1a365d]">거래 내역</h3>
+        <div className="flex gap-2">
+          {statusOptions.map((option) => (
+            <button
+              key={option.value}
+              onClick={() => handleStatusChange(option.value)}
+              className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
+                selectedStatus === option.value
+                  ? option.color
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              }`}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {loading && transactions.length === 0 ? (
+        <div className="text-center py-8">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-purple-600 mx-auto"></div>
+          <p className="mt-2 text-gray-600">거래 내역을 불러오는 중...</p>
+        </div>
+      ) : transactions.length === 0 ? (
+        <div className="text-center py-8">
+          <div className="text-gray-400 text-4xl mb-2">📋</div>
+          <p className="text-gray-600">거래 내역이 없습니다.</p>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {transactions.map((transaction) => (
+            <div
+              key={transaction.id}
+              onClick={() => onTransactionSelect(transaction)}
+              className="border border-gray-200 rounded-xl p-4 hover:shadow-lg transition-all duration-300 cursor-pointer bg-white/50"
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-4">
+                  <div className="bg-gray-100 rounded-full w-12 h-12 flex items-center justify-center">
+                    <span className="text-lg">{transaction.patentIcon}</span>
+                  </div>
+                  <div>
+                    <h4 className="font-bold text-[#1a365d] text-sm mb-1">
+                      {transaction.patentTitle}
+                    </h4>
+                    <p className="text-gray-600 text-xs">
+                      {transaction.buyerId === user?.id ? '구매' : '판매'} • {formatDate(transaction.createdAt)}
+                    </p>
+                    <p className="text-gray-500 text-xs">
+                      {transaction.buyerId === user?.id 
+                        ? `판매자: ${transaction.sellerName}`
+                        : `구매자: ${transaction.buyerName}`
+                      }
+                    </p>
+                  </div>
+                </div>
+                <div className="text-right">
+                  <div className="font-bold text-[#1a365d] text-sm mb-1">
+                    ₩{formatPrice(transaction.price)}
+                  </div>
+                  <span className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(transaction.status)}`}>
+                    {getStatusLabel(transaction.status)}
+                  </span>
+                </div>
+              </div>
+            </div>
+          ))}
+          
+          {hasMore && (
+            <div className="text-center pt-4">
+              <button
+                onClick={handleLoadMore}
+                disabled={loading}
+                className="px-6 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {loading ? '로딩 중...' : '더 보기'}
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TransactionList; 

--- a/src/components/trade/TradeDetail.tsx
+++ b/src/components/trade/TradeDetail.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { tradeAPI, TradeDetailDto } from '@/utils/apiClient';
+
+interface TradeDetailProps {
+  tradeId: number | null;
+  onClose: () => void;
+}
+
+export default function TradeDetail({ tradeId, onClose }: TradeDetailProps) {
+  const [tradeDetail, setTradeDetail] = useState<TradeDetailDto | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (tradeId) {
+      fetchTradeDetail(tradeId);
+    }
+  }, [tradeId]);
+
+  const fetchTradeDetail = async (id: number) => {
+    try {
+      setLoading(true);
+      setError(null);
+      const detail = await tradeAPI.getTradeDetail(id);
+      setTradeDetail(detail);
+    } catch (err) {
+      setError('거래 상세 정보를 불러오는데 실패했습니다.');
+      console.error('Error fetching trade detail:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case 'COMPLETED':
+        return 'bg-green-100 text-green-800';
+      case 'PENDING':
+        return 'bg-yellow-100 text-yellow-800';
+      case 'CANCELLED':
+        return 'bg-red-100 text-red-800';
+      default:
+        return 'bg-gray-100 text-gray-800';
+    }
+  };
+
+  const getStatusText = (status: string) => {
+    switch (status) {
+      case 'COMPLETED':
+        return '완료';
+      case 'PENDING':
+        return '진행중';
+      case 'CANCELLED':
+        return '취소됨';
+      default:
+        return status;
+    }
+  };
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString('ko-KR', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit'
+    });
+  };
+
+  const formatPrice = (price: number) => {
+    return new Intl.NumberFormat('ko-KR').format(price);
+  };
+
+  if (!tradeId) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-2xl p-6 max-w-2xl w-full max-h-[90vh] overflow-y-auto">
+        <div className="flex justify-between items-center mb-6">
+          <h2 className="text-xl font-bold text-gray-900">거래 상세 내역</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-700 text-2xl"
+          >
+            ×
+          </button>
+        </div>
+
+        {loading && (
+          <div className="text-center py-8">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-purple-600 mx-auto"></div>
+            <p className="mt-2 text-gray-600">거래 정보를 불러오는 중...</p>
+          </div>
+        )}
+
+        {error && (
+          <div className="text-center py-8">
+            <p className="text-red-600 mb-4">{error}</p>
+            <button 
+              onClick={() => fetchTradeDetail(tradeId)}
+              className="px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700"
+            >
+              다시 시도
+            </button>
+          </div>
+        )}
+
+        {tradeDetail && !loading && (
+          <div className="space-y-6">
+            {/* 거래 기본 정보 */}
+            <div className="bg-gray-50 rounded-xl p-4">
+              <h3 className="font-bold text-gray-900 mb-3">거래 정보</h3>
+              <div className="grid grid-cols-2 gap-4 text-sm">
+                <div>
+                  <span className="text-gray-600">거래 ID:</span>
+                  <p className="font-medium text-gray-900">#{tradeDetail.id}</p>
+                </div>
+                <div>
+                  <span className="text-gray-600">거래 상태:</span>
+                  <p>
+                    <span className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(tradeDetail.status)}`}>
+                      {getStatusText(tradeDetail.status)}
+                    </span>
+                  </p>
+                </div>
+                <div>
+                  <span className="text-gray-600">거래 금액:</span>
+                  <p className="font-bold text-lg text-purple-600">₩{formatPrice(tradeDetail.price)}</p>
+                </div>
+                <div>
+                  <span className="text-gray-600">거래 일시:</span>
+                  <p className="font-medium text-gray-900">{formatDate(tradeDetail.createdAt)}</p>
+                </div>
+              </div>
+            </div>
+
+            {/* 게시글 정보 */}
+            <div className="bg-blue-50 rounded-xl p-4">
+              <h3 className="font-bold text-gray-900 mb-3">게시글 정보</h3>
+              <div className="space-y-3">
+                <div>
+                  <span className="text-gray-600 text-sm">제목:</span>
+                  <p className="font-medium text-lg text-gray-900">{tradeDetail.postTitle}</p>
+                </div>
+                <div>
+                  <span className="text-gray-600 text-sm">카테고리:</span>
+                  <p className="font-medium text-gray-900">{tradeDetail.postCategory}</p>
+                </div>
+              </div>
+            </div>
+
+            {/* 거래 당사자 정보 */}
+            <div className="bg-green-50 rounded-xl p-4">
+              <h3 className="font-bold text-gray-900 mb-3">거래 당사자</h3>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <span className="text-gray-600 text-sm">판매자:</span>
+                  <p className="font-medium text-gray-900">{tradeDetail.sellerEmail}</p>
+                </div>
+                <div>
+                  <span className="text-gray-600 text-sm">구매자:</span>
+                  <p className="font-medium text-gray-900">{tradeDetail.buyerEmail}</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div className="mt-6 flex justify-end">
+          <button
+            onClick={onClose}
+            className="px-6 py-2 bg-gray-500 text-white rounded-lg hover:bg-gray-600 transition-colors"
+          >
+            닫기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+} 

--- a/src/components/trade/TradeHistory.tsx
+++ b/src/components/trade/TradeHistory.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { tradeAPI, TradeDto } from '@/utils/apiClient';
+
+interface TradeHistoryProps {
+  onTradeSelect: (tradeId: number) => void;
+}
+
+export default function TradeHistory({ onTradeSelect }: TradeHistoryProps) {
+  const [trades, setTrades] = useState<TradeDto[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+  const [totalElements, setTotalElements] = useState(0);
+
+  const fetchTrades = async (page: number = 0) => {
+    try {
+      setLoading(true);
+      const response = await tradeAPI.getMyTrades(page, 10);
+      setTrades(response.content);
+      setTotalPages(response.totalPages);
+      setTotalElements(response.totalElements);
+      setCurrentPage(response.page);
+    } catch (err) {
+      setError('거래내역을 불러오는데 실패했습니다.');
+      console.error('Error fetching trades:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchTrades();
+  }, []);
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case 'COMPLETED':
+        return 'bg-green-100 text-green-800';
+      case 'PENDING':
+        return 'bg-yellow-100 text-yellow-800';
+      case 'CANCELLED':
+        return 'bg-red-100 text-red-800';
+      default:
+        return 'bg-gray-100 text-gray-800';
+    }
+  };
+
+  const getStatusText = (status: string) => {
+    switch (status) {
+      case 'COMPLETED':
+        return '완료';
+      case 'PENDING':
+        return '진행중';
+      case 'CANCELLED':
+        return '취소됨';
+      default:
+        return status;
+    }
+  };
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString('ko-KR', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  };
+
+  const formatPrice = (price: number) => {
+    return new Intl.NumberFormat('ko-KR').format(price);
+  };
+
+  if (loading) {
+    return (
+      <div className="bg-white/95 backdrop-blur-sm rounded-2xl p-6 shadow-xl">
+        <h3 className="text-lg font-bold text-[#1a365d] mb-4">거래내역</h3>
+        <div className="text-center py-8">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-purple-600 mx-auto"></div>
+          <p className="mt-2 text-gray-600">거래내역을 불러오는 중...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-white/95 backdrop-blur-sm rounded-2xl p-6 shadow-xl">
+        <h3 className="text-lg font-bold text-[#1a365d] mb-4">거래내역</h3>
+        <div className="text-center py-8">
+          <p className="text-red-600">{error}</p>
+          <button 
+            onClick={() => fetchTrades()}
+            className="mt-2 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700"
+          >
+            다시 시도
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white/95 backdrop-blur-sm rounded-2xl p-6 shadow-xl">
+      <h3 className="text-lg font-bold text-[#1a365d] mb-4">거래내역</h3>
+      
+      {trades.length === 0 ? (
+        <div className="text-center py-8">
+          <p className="text-gray-600">거래내역이 없습니다.</p>
+        </div>
+      ) : (
+        <>
+          <div className="space-y-4">
+            {trades.map((trade) => (
+              <div 
+                key={trade.id}
+                className="border border-gray-200 rounded-xl p-4 bg-white/50 hover:bg-white/70 transition-colors cursor-pointer"
+                onClick={() => onTradeSelect(trade.id)}
+              >
+                                 <div className="flex justify-between items-start mb-2">
+                   <div className="flex-1">
+                     <div className="flex items-center gap-2 mb-1">
+                       <span className="text-sm text-gray-500">거래 #{trade.id}</span>
+                       <span className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(trade.status)}`}>
+                         {getStatusText(trade.status)}
+                       </span>
+                     </div>
+                   </div>
+                   <div className="text-right">
+                     <p className="font-bold text-lg text-[#1a365d]">₩{formatPrice(trade.price)}</p>
+                   </div>
+                 </div>
+                <div className="flex justify-between items-center text-xs text-gray-500">
+                  <span>판매자: {trade.sellerId}</span>
+                  <span>구매자: {trade.buyerId}</span>
+                </div>
+                <div className="text-xs text-gray-400 mt-1">
+                  {formatDate(trade.createdAt)}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* 페이지네이션 */}
+          {totalPages > 1 && (
+            <div className="flex justify-center items-center gap-2 mt-6">
+              <button
+                onClick={() => fetchTrades(currentPage - 1)}
+                disabled={currentPage === 0}
+                className="px-3 py-1 rounded-lg border border-gray-300 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50"
+              >
+                이전
+              </button>
+              <span className="text-sm text-gray-600">
+                {currentPage + 1} / {totalPages}
+              </span>
+              <button
+                onClick={() => fetchTrades(currentPage + 1)}
+                disabled={currentPage >= totalPages - 1}
+                className="px-3 py-1 rounded-lg border border-gray-300 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50"
+              >
+                다음
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+} 

--- a/src/utils/apiClient.ts
+++ b/src/utils/apiClient.ts
@@ -140,4 +140,51 @@ export const memberAPI = {
   },
 };
 
+// 거래 관련 API 함수들
+export const tradeAPI = {
+  // 본인 모든 거래 조회
+  getMyTrades: async (page: number = 0, size: number = 10): Promise<{
+    content: TradeDto[];
+    page: number;
+    size: number;
+    totalElements: number;
+    totalPages: number;
+    last: boolean;
+  }> => {
+    const response = await apiClient.get("/api/trades", {
+      params: { page, size },
+    });
+    return response.data.data;
+  },
+
+  // 거래 상세 조회
+  getTradeDetail: async (tradeId: number): Promise<TradeDetailDto> => {
+    const response = await apiClient.get(`/api/trades/${tradeId}`);
+    return response.data.data;
+  },
+};
+
+// 거래 관련 타입 정의
+export interface TradeDto {
+  id: number;
+  postId: number;
+  sellerId: number;
+  buyerId: number;
+  price: number;
+  status: string;
+  createdAt: string;
+}
+
+export interface TradeDetailDto {
+  id: number;
+  postId: number;
+  postTitle: string;
+  postCategory: string;
+  price: number;
+  status: string;
+  createdAt: string;
+  sellerEmail: string;
+  buyerEmail: string;
+}
+
 export default apiClient;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 마이페이지에 '거래 내역' 섹션이 추가되어 사용자가 자신의 특허 거래 이력을 확인할 수 있습니다.
  * 거래 내역에서 항목을 선택하면 상세 정보를 모달로 확인할 수 있습니다.
  * 거래 상세 보기에서는 거래 상태, 가격, 생성일, 게시글 정보, 판매자/구매자 이메일 등 주요 정보를 제공합니다.
  * 거래 내역은 페이지네이션 및 상태별 배지, 빈 상태 안내, 오류 처리 등이 포함되어 있습니다.

* **버그 수정**
  * '좋아요한 특허' 섹션의 일부 UI 포맷이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->