### PR TITLE
[feat] 관리자 대시보드 페이지 추가

### DIFF
--- a/src/app/admin/members/page.tsx
+++ b/src/app/admin/members/page.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import React, { useState, useEffect } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import { useRouter } from "next/navigation";
+import { adminAPI } from "@/utils/apiClient";
+import AdminNavigation from "@/components/AdminNavigation";
+
+interface Member {
+  id: number;
+  email: string;
+  name: string;
+  role: string;
+  profileUrl?: string;
+  status: string;
+  createdAt: string;
+  deletedAt?: string;
+}
+
+export default function AdminMembersPage() {
+  const { user, isAuthenticated, loading } = useAuth();
+  const router = useRouter();
+  const [members, setMembers] = useState<Member[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  // 로그인하지 않은 사용자나 ADMIN이 아닌 사용자는 접근 차단
+  useEffect(() => {
+    if (!loading) {
+      if (!isAuthenticated) {
+        router.push('/login');
+      } else if (user?.role !== 'ADMIN') {
+        router.push('/');
+      }
+    }
+  }, [isAuthenticated, loading, user, router]);
+
+  // 회원 목록 가져오기
+  useEffect(() => {
+    if (user?.role === 'ADMIN') {
+      fetchMembers();
+    }
+  }, [user]);
+
+  const fetchMembers = async () => {
+    try {
+      setIsLoading(true);
+      const response = await adminAPI.getAllMembers();
+      // 백엔드 응답 구조에 맞게 수정
+      setMembers(response.data?.content || []);
+    } catch (error) {
+      console.error('회원 목록 조회 실패:', error);
+      setError('회원 목록을 불러오는데 실패했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 로딩 중이거나 인증되지 않은 경우 로딩 표시
+  if (loading || !isAuthenticated || user?.role !== 'ADMIN') {
+    return (
+      <div className="pb-10">
+        <section className="px-6 py-8">
+          <div className="max-w-7xl mx-auto">
+            <div className="bg-white/95 backdrop-blur-sm rounded-2xl p-6 shadow-xl">
+              <div className="text-center">
+                <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-600 mx-auto"></div>
+                <p className="mt-4 text-gray-600">로딩 중...</p>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    );
+  }
+
+  return (
+    <div className="pb-10">
+      <section className="px-6 py-8">
+        <div className="max-w-7xl mx-auto">
+          <div className="flex items-center justify-between mb-8">
+            <h1 className="text-2xl font-bold text-white">관리자 - 회원 관리</h1>
+          </div>
+          
+          {/* 관리자 네비게이션 */}
+          <AdminNavigation user={user} />
+
+          {/* 회원 목록 카드 */}
+          <div className="bg-white/95 backdrop-blur-sm rounded-2xl p-6 shadow-xl">
+            <div className="flex items-center justify-between mb-6">
+              <h3 className="text-lg font-bold text-[#1a365d]">회원 목록</h3>
+              <div className="text-sm text-gray-600">
+                총 {members.length}명의 회원
+              </div>
+            </div>
+
+            {error && (
+              <div className="mb-4 p-4 bg-red-100 border border-red-400 text-red-700 rounded-lg">
+                {error}
+              </div>
+            )}
+
+            {isLoading ? (
+              <div className="text-center py-8">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-purple-600 mx-auto mb-4"></div>
+                <p className="text-gray-600">회원 목록을 불러오는 중...</p>
+              </div>
+            ) : members.length === 0 ? (
+              <div className="text-center py-8">
+                <div className="text-gray-400 text-6xl mb-4">👥</div>
+                <p className="text-gray-600">등록된 회원이 없습니다.</p>
+                <p className="text-sm text-gray-500 mt-2">
+                  백엔드에서 관리자 API가 구현되면 회원 목록이 표시됩니다.
+                </p>
+              </div>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-gray-200">
+                      <th className="text-left py-3 px-4 font-medium text-gray-700">ID</th>
+                      <th className="text-left py-3 px-4 font-medium text-gray-700">이름</th>
+                      <th className="text-left py-3 px-4 font-medium text-gray-700">이메일</th>
+                      <th className="text-left py-3 px-4 font-medium text-gray-700">권한</th>
+                      <th className="text-left py-3 px-4 font-medium text-gray-700">상태</th>
+                      <th className="text-left py-3 px-4 font-medium text-gray-700">가입일</th>
+                      <th className="text-left py-3 px-4 font-medium text-gray-700">관리</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {members.map((member) => (
+                      <tr key={member.id} className="border-b border-gray-100 hover:bg-gray-50">
+                        <td className="py-3 px-4 text-gray-500">{member.id}</td>
+                        <td className="py-3 px-4 text-gray-900">{member.name}</td>
+                        <td className="py-3 px-4 text-gray-900">{member.email}</td>
+                        <td className="py-3 px-4">
+                          <span className={`px-2 py-1 rounded-full text-xs ${
+                            member.role === 'ADMIN' 
+                              ? 'bg-red-100 text-red-800' 
+                              : 'bg-blue-100 text-blue-800'
+                          }`}>
+                            {member.role}
+                          </span>
+                        </td>
+                        <td className="py-3 px-4">
+                          <span className={`px-2 py-1 rounded-full text-xs ${
+                            member.status === 'ACTIVE' 
+                              ? 'bg-green-100 text-green-800' 
+                              : member.status === 'DELETED'
+                              ? 'bg-red-100 text-red-800'
+                              : 'bg-gray-100 text-gray-800'
+                          }`}>
+                            {member.status}
+                          </span>
+                        </td>
+                        <td className="py-3 px-4 text-gray-500">
+                          {new Date(member.createdAt).toLocaleDateString()}
+                        </td>
+                        <td className="py-3 px-4">
+                          <div className="flex gap-2">
+                            <button className="text-blue-600 hover:text-blue-700 text-xs">
+                              수정
+                            </button>
+                            <button className="text-red-600 hover:text-red-700 text-xs">
+                              삭제
+                            </button>
+                          </div>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+} 

--- a/src/app/admin/patents/page.tsx
+++ b/src/app/admin/patents/page.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import React, { useState, useEffect } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import { useRouter } from "next/navigation";
+import AdminNavigation from "@/components/AdminNavigation";
+import { adminAPI } from "@/utils/apiClient";
+
+interface Patent {
+  id: number;
+  title: string;
+  price: number;
+  category: string;
+  favoriteCnt: number;
+  createdAt: string;
+  imageUrl?: string;
+}
+
+export default function AdminPatentsPage() {
+  const { user, isAuthenticated, loading } = useAuth();
+  const router = useRouter();
+  const [patents, setPatents] = useState<Patent[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  // 로그인하지 않은 사용자나 ADMIN이 아닌 사용자는 접근 차단
+  useEffect(() => {
+    if (!loading) {
+      if (!isAuthenticated) {
+        router.push('/login');
+      } else if (user?.role !== 'ADMIN') {
+        router.push('/');
+      }
+    }
+  }, [isAuthenticated, loading, user, router]);
+
+  // 특허 목록 가져오기
+  useEffect(() => {
+    if (user?.role === 'ADMIN') {
+      fetchPatents();
+    }
+  }, [user]);
+
+  const fetchPatents = async () => {
+    try {
+      setIsLoading(true);
+      const response = await adminAPI.getAllPatents();
+      // 백엔드 응답 구조에 맞게 수정 - response.data가 아닌 response 자체가 배열
+      setPatents(response || []);
+    } catch (error) {
+      console.error('특허 목록 조회 실패:', error);
+      setError('특허 목록을 불러오는데 실패했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 로딩 중이거나 인증되지 않은 경우 로딩 표시
+  if (loading || !isAuthenticated || user?.role !== 'ADMIN') {
+    return (
+      <div className="pb-10">
+        <section className="px-6 py-8">
+          <div className="max-w-7xl mx-auto">
+            <div className="bg-white/95 backdrop-blur-sm rounded-2xl p-6 shadow-xl">
+              <div className="text-center">
+                <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-600 mx-auto"></div>
+                <p className="mt-4 text-gray-600">로딩 중...</p>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    );
+  }
+
+  return (
+    <div className="pb-10">
+      <section className="px-6 py-8">
+        <div className="max-w-7xl mx-auto">
+          <div className="flex items-center justify-between mb-8">
+            <h1 className="text-2xl font-bold text-white">관리자 - 특허 관리</h1>
+          </div>
+          
+          {/* 관리자 네비게이션 */}
+          <AdminNavigation user={user} />
+
+          {/* 특허 목록 카드 */}
+          <div className="bg-white/95 backdrop-blur-sm rounded-2xl p-6 shadow-xl">
+            <div className="flex items-center justify-between mb-6">
+              <h3 className="text-lg font-bold text-[#1a365d]">특허 목록</h3>
+              <div className="text-sm text-gray-600">
+                총 {patents.length}개의 특허
+              </div>
+            </div>
+
+            {error && (
+              <div className="mb-4 p-4 bg-red-100 border border-red-400 text-red-700 rounded-lg">
+                {error}
+              </div>
+            )}
+
+            {isLoading ? (
+              <div className="text-center py-8">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-purple-600 mx-auto mb-4"></div>
+                <p className="text-gray-600">특허 목록을 불러오는 중...</p>
+              </div>
+            ) : patents.length === 0 ? (
+              <div className="text-center py-8">
+                <div className="text-gray-400 text-6xl mb-4">📋</div>
+                <p className="text-gray-600">등록된 특허가 없습니다.</p>
+                <p className="text-sm text-gray-500 mt-2">
+                  백엔드에서 관리자 API가 구현되면 특허 목록이 표시됩니다.
+                </p>
+              </div>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                                     <thead>
+                     <tr className="border-b border-gray-200">
+                       <th className="text-left py-3 px-4 font-medium text-gray-700">ID</th>
+                       <th className="text-left py-3 px-4 font-medium text-gray-700">제목</th>
+                       <th className="text-left py-3 px-4 font-medium text-gray-700">카테고리</th>
+                       <th className="text-left py-3 px-4 font-medium text-gray-700">가격</th>
+                       <th className="text-left py-3 px-4 font-medium text-gray-700">좋아요</th>
+                       <th className="text-left py-3 px-4 font-medium text-gray-700">등록일</th>
+                       <th className="text-left py-3 px-4 font-medium text-gray-700">관리</th>
+                     </tr>
+                   </thead>
+                  <tbody>
+                                         {patents.map((patent) => (
+                       <tr key={patent.id} className="border-b border-gray-100 hover:bg-gray-50">
+                         <td className="py-3 px-4 text-gray-500">{patent.id}</td>
+                         <td className="py-3 px-4 text-gray-900 font-medium">{patent.title}</td>
+                         <td className="py-3 px-4 text-gray-500">{patent.category}</td>
+                         <td className="py-3 px-4 text-gray-500">{patent.price.toLocaleString()}원</td>
+                         <td className="py-3 px-4 text-gray-500">{patent.favoriteCnt}</td>
+                         <td className="py-3 px-4 text-gray-500">
+                           {new Date(patent.createdAt).toLocaleDateString()}
+                         </td>
+                         <td className="py-3 px-4">
+                           <div className="flex gap-2">
+                             <button className="text-blue-600 hover:text-blue-700 text-xs">
+                               보기
+                             </button>
+                             <button className="text-yellow-600 hover:text-yellow-700 text-xs">
+                               수정
+                             </button>
+                             <button className="text-red-600 hover:text-red-700 text-xs">
+                               삭제
+                             </button>
+                           </div>
+                         </td>
+                       </tr>
+                     ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+} 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -7,7 +7,7 @@ import apiClient from "@/utils/apiClient";
 
 export default function LoginPage() {
   const router = useRouter();
-  const { login, isAuthenticated, loading } = useAuth();
+  const { login, isAuthenticated, loading, user } = useAuth();
   const [formData, setFormData] = useState({
     email: "",
     password: "",
@@ -18,9 +18,14 @@ export default function LoginPage() {
   // 로그인 상태에서 로그인 페이지 접근 방지
   useEffect(() => {
     if (!loading && isAuthenticated) {
-      router.push("/");
+      // Role에 따라 리다이렉트
+      if (user?.role === 'ADMIN') {
+        router.push("/admin/members");
+      } else {
+        router.push("/");
+      }
     }
-  }, [isAuthenticated, loading, router]);
+  }, [isAuthenticated, loading, user, router]);
 
   // 로딩 중이거나 이미 로그인된 경우 로딩 화면 표시
   if (loading || isAuthenticated) {
@@ -62,11 +67,19 @@ export default function LoginPage() {
             id: memberInfo.id.toString(),
             email: memberInfo.email,
             name: memberInfo.name,
+            role: memberInfo.role || 'USER',
           }, accessToken, refreshToken);
         }
         
-        // 로그인 성공 시 메인 페이지로 리다이렉트
-        router.push("/");
+        // Role에 따라 리다이렉트
+        const userRole = memberInfo?.role || 'USER';
+        if (userRole === 'ADMIN') {
+          // 관리자는 관리자 페이지로 리다이렉트
+          router.push("/admin/members");
+        } else {
+          // 일반 사용자는 메인 페이지로 리다이렉트
+          router.push("/");
+        }
       } else {
         setError("로그인 응답 데이터가 올바르지 않습니다.");
       }

--- a/src/components/AdminLoadingSpinner.tsx
+++ b/src/components/AdminLoadingSpinner.tsx
@@ -1,0 +1,16 @@
+export default function AdminLoadingSpinner() {
+  return (
+    <div className="pb-10">
+      <section className="px-6 py-8">
+        <div className="max-w-7xl mx-auto">
+          <div className="bg-white/95 backdrop-blur-sm rounded-2xl p-6 shadow-xl">
+            <div className="text-center">
+              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-600 mx-auto"></div>
+              <p className="mt-4 text-gray-600">로딩 중...</p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+} 

--- a/src/components/AdminNavigation.tsx
+++ b/src/components/AdminNavigation.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import React from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+interface AdminNavigationProps {
+  user?: {
+    name: string;
+    email: string;
+  };
+}
+
+export default function AdminNavigation({ user }: AdminNavigationProps) {
+  const pathname = usePathname();
+
+  const navItems = [
+    { href: '/admin/members', label: '회원 관리', icon: '👥' },
+    { href: '/admin/patents', label: '특허 관리', icon: '📋' },
+  ];
+
+  return (
+    <div className="bg-white/95 backdrop-blur-sm rounded-2xl p-6 mb-6 shadow-xl">
+      {/* 관리자 정보 */}
+      <div className="flex items-center gap-4 mb-6">
+        <div className="bg-red-100 rounded-full w-12 h-12 flex items-center justify-center">
+          <span className="text-red-600 text-xl">👑</span>
+        </div>
+        <div>
+          <h2 className="text-lg font-bold text-[#1a365d]">관리자 계정</h2>
+          <p className="text-gray-600 text-sm">{user?.name} ({user?.email})</p>
+        </div>
+      </div>
+
+      {/* 네비게이션 메뉴 */}
+      <div className="flex gap-2">
+        {navItems.map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+              pathname === item.href
+                ? 'bg-purple-100 text-purple-700 border border-purple-200'
+                : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+            }`}
+          >
+            <span className="text-lg">{item.icon}</span>
+            {item.label}
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+} 

--- a/src/components/AdminNavigation.tsx
+++ b/src/components/AdminNavigation.tsx
@@ -28,7 +28,9 @@ export default function AdminNavigation({ user }: AdminNavigationProps) {
         </div>
         <div>
           <h2 className="text-lg font-bold text-[#1a365d]">관리자 계정</h2>
-          <p className="text-gray-600 text-sm">{user?.name} ({user?.email})</p>
+          <p className="text-gray-600 text-sm">
+            {user ? `${user.name} (${user.email})` : '관리자'}
+          </p>
         </div>
       </div>
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -69,6 +69,14 @@ const Header = () => {
               <Link href="/mypage" className="hover:text-indigo-500 transition-colors">
                 마이페이지
               </Link>
+              {user?.role === 'ADMIN' && (
+                <Link 
+                  href="/admin/members" 
+                  className="hover:text-indigo-500 transition-colors"
+                >
+                  관리페이지
+                </Link>
+              )}
               <button
                 onClick={handleLogout}
                 className="hover:text-indigo-500 transition-colors cursor-pointer"

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -16,6 +16,7 @@ interface User {
   email: string;
   name: string;
   profileUrl: string | null;
+  role: string;
   // 필요한 다른 사용자 정보들
 }
 
@@ -80,6 +81,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           email: response.data.data.email,
           name: response.data.data.name,
           profileUrl: response.data.data.profileUrl,
+          role: response.data.data.role || 'USER',
         };
         
         return userData;

--- a/src/hooks/useAdminTable.ts
+++ b/src/hooks/useAdminTable.ts
@@ -1,0 +1,84 @@
+import { useState, useEffect } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { useRouter } from 'next/navigation';
+
+export function useAdminTable<T>(
+  fetchData: () => Promise<T[]>,
+  requiredRole: string = 'ADMIN'
+) {
+  const { user, isAuthenticated, loading } = useAuth();
+  const router = useRouter();
+  const [data, setData] = useState<T[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  // 공통 인증 로직
+  useEffect(() => {
+    if (!loading) {
+      if (!isAuthenticated) {
+        router.push('/login');
+        return;
+      } else if (user?.role !== requiredRole) {
+        router.push('/');
+        return;
+      }
+    }
+  }, [isAuthenticated, loading, user, router, requiredRole]);
+
+  // 공통 데이터 페칭 로직
+  useEffect(() => {
+    if (user?.role === requiredRole) {
+      fetchDataHandler();
+    }
+  }, [user, requiredRole]);
+
+  const fetchDataHandler = async () => {
+    try {
+      setIsLoading(true);
+      setError("");
+      const result = await fetchData();
+      setData(result);
+    } catch (error: any) {
+      console.error('데이터 조회 실패:', error);
+      
+      // 구체적인 에러 메시지 제공
+      let errorMessage = '데이터를 불러오는데 실패했습니다.';
+      
+      if (error.response) {
+        // 서버 응답 에러
+        const status = error.response.status;
+        if (status === 401) {
+          errorMessage = '인증이 필요합니다. 다시 로그인해주세요.';
+        } else if (status === 403) {
+          errorMessage = '관리자 권한이 필요합니다.';
+        } else if (status === 404) {
+          errorMessage = 'API 엔드포인트를 찾을 수 없습니다.';
+        } else if (status >= 500) {
+          errorMessage = '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+        } else {
+          errorMessage = `서버 오류 (${status}): ${error.response.data?.message || '알 수 없는 오류'}`;
+        }
+      } else if (error.request) {
+        // 네트워크 에러
+        errorMessage = '서버에 연결할 수 없습니다. 네트워크 연결을 확인해주세요.';
+      } else {
+        // 기타 에러
+        errorMessage = `오류가 발생했습니다: ${error.message}`;
+      }
+      
+      setError(errorMessage);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { 
+    user, 
+    isAuthenticated, 
+    loading, 
+    data, 
+    isLoading, 
+    error, 
+    refetch: fetchDataHandler 
+  };
+} 

--- a/src/hooks/useAdminTable.ts
+++ b/src/hooks/useAdminTable.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useRouter } from 'next/navigation';
 
@@ -32,7 +32,7 @@ export function useAdminTable<T>(
     }
   }, [user, requiredRole]);
 
-  const fetchDataHandler = async () => {
+  const fetchDataHandler = useCallback(async () => {
     try {
       setIsLoading(true);
       setError("");
@@ -70,7 +70,7 @@ export function useAdminTable<T>(
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [fetchData]);
 
   return { 
     user, 

--- a/src/utils/apiClient.ts
+++ b/src/utils/apiClient.ts
@@ -187,4 +187,47 @@ export interface TradeDetailDto {
   buyerEmail: string;
 }
 
+// 관리자 관련 API 함수들
+export const adminAPI = {
+  // 전체 회원 목록 조회 (관리자 전용)
+  getAllMembers: async (): Promise<any> => {
+    const response = await apiClient.get('/api/admin/members');
+    return response.data;
+  },
+
+  // 회원 정보 수정 (관리자 전용)
+  updateMemberByAdmin: async (memberId: number, data: {
+    name?: string;
+    role?: string;
+    status?: string;
+  }): Promise<void> => {
+    await apiClient.patch(`/api/admin/members/${memberId}`, data);
+  },
+
+  // 회원 삭제 (관리자 전용)
+  deleteMemberByAdmin: async (memberId: number): Promise<void> => {
+    await apiClient.delete(`/api/admin/members/${memberId}`);
+  },
+
+  // 전체 특허 목록 조회 (관리자 전용)
+  getAllPatents: async (): Promise<any> => {
+    const response = await apiClient.get('/api/posts');
+    return response.data;
+  },
+
+  // 특허 정보 수정 (관리자 전용)
+  updatePatentByAdmin: async (patentId: number, data: {
+    title?: string;
+    description?: string;
+    status?: string;
+  }): Promise<void> => {
+    await apiClient.patch(`/api/admin/patents/${patentId}`, data);
+  },
+
+  // 특허 삭제 (관리자 전용)
+  deletePatentByAdmin: async (patentId: number): Promise<void> => {
+    await apiClient.delete(`/api/admin/patents/${patentId}`);
+  },
+};
+
 export default apiClient;


### PR DESCRIPTION
1. 로그인페이지에서 로그인시 ROLE에 따라 리다이렉트 두갈래로 나뉘게 변경
   USER -> 메인 페이지로
   ADMIN -> 회원 목록 페이지로
2. 관리페이지 메뉴 페이지 추가(ROLE이 ADMIN인 계정만 보임)
3. 관리페이지에서 "회원목록", "특허목록" 추가

=======
관리자가 상세 조회, 수정, 삭제 등은 아직 붙이지 못했음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 관리자 전용 회원 관리 및 특허 관리 페이지가 추가되어, 관리자가 회원과 특허 정보를 테이블로 조회 및 관리(수정/삭제)할 수 있습니다.
  * 관리자 전용 네비게이션 컴포넌트가 추가되어, 관리자 정보와 관리 메뉴를 제공합니다.
  * 헤더에 관리자 로그인 시 "관리페이지" 링크가 노출됩니다.
  * 관리자 전용 로딩 스피너 컴포넌트가 추가되어, 데이터 로딩 중 시각적 피드백을 제공합니다.
  * 관리자 전용 데이터 관리용 커스텀 훅이 도입되어, 권한 검사와 데이터 상태 관리를 지원합니다.

* **개선 사항**
  * 로그인 및 인증 로직이 개선되어, 사용자 역할에 따라 로그인 후 또는 로그인 페이지 접근 시 자동으로 적절한 페이지로 이동합니다.
  * 인증 컨텍스트의 사용자 정보에 역할(role) 속성이 추가되어, 항상 역할 정보가 포함됩니다.

* **API**
  * 관리자 전용 회원 및 특허 관리 API 함수가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->