### PR TITLE
[feat] 게시글 상세페이지 구매하기 버튼 추가

### DIFF
--- a/src/app/patents/[id]/page.tsx
+++ b/src/app/patents/[id]/page.tsx
@@ -5,6 +5,7 @@ import apiClient from '@/utils/apiClient';
 import { useAuth } from '@/contexts/AuthContext';
 import { useChat } from '@/contexts/ChatContext';
 import { useParams, useRouter } from 'next/navigation';
+import { tradeAPI } from '@/utils/apiClient';
 
 interface FileUploadResponse {
   id: number;
@@ -274,8 +275,8 @@ export default function PatentDetailPage() {
   
     setIsBuying(true);
     try {
-      await apiClient.post("/api/trades", { postId: post.id });
-      alert('구매가가 완료되었습니다.');
+      await tradeAPI.createTrade(post.id);
+      alert('구매가 완료되었습니다.');
       router.push('/mypage');
     } catch (err: any) {
       alert(err?.response?.data?.msg || '거래 생성에 실패했습니다.');

--- a/src/app/patents/[id]/page.tsx
+++ b/src/app/patents/[id]/page.tsx
@@ -102,6 +102,7 @@ export default function PatentDetailPage() {
   const [loading, setLoading] = useState(true);
   const [likeLoading, setLikeLoading] = useState(false);
   const [isCreatingRoom, setIsCreatingRoom] = useState(false);
+  const [isBuying, setIsBuying] = useState(false);
 
   useEffect(() => {
     if (!authLoading) {
@@ -267,6 +268,22 @@ export default function PatentDetailPage() {
     );
   }
 
+  const handleBuy = async () => {
+    if (!isAuthenticated) return router.push('/login');
+    if (!post) return;
+  
+    setIsBuying(true);
+    try {
+      await apiClient.post("/api/trades", { postId: post.id });
+      alert('구매가가 완료되었습니다.');
+      router.push('/mypage');
+    } catch (err: any) {
+      alert(err?.response?.data?.msg || '거래 생성에 실패했습니다.');
+    } finally {
+      setIsBuying(false);
+    }
+  };
+
   const categoryStyle =
     colorMap[post.category] || { bg: 'bg-gray-100', text: 'text-gray-600' };
 
@@ -402,6 +419,22 @@ export default function PatentDetailPage() {
 
             {/* Action Buttons */}
             <div className="flex flex-col sm:flex-row gap-4">
+              {post.status === '판매중' ? (
+                <button
+                  className="bg-green-600 hover:bg-green-700 text-white px-6 py-3 rounded-lg transition-colors flex-1 disabled:opacity-50 disabled:cursor-not-allowed"
+                  onClick={handleBuy}
+                  disabled={isBuying}
+                >
+                  {isBuying ? '구매 요청 중...' : '구매하기'}
+                </button>
+              ) : (
+                <button
+                  className="bg-gray-400 text-white px-6 py-3 rounded-lg transition-colors flex-1 cursor-not-allowed"
+                  disabled
+                >
+                  판매 완료
+                </button>
+              )}
               <button 
                 className="bg-purple-600 hover:bg-purple-700 text-white px-6 py-3 rounded-lg transition-colors flex-1 disabled:opacity-50 disabled:cursor-not-allowed"
                 onClick={handlePurchaseInquiry}

--- a/src/utils/apiClient.ts
+++ b/src/utils/apiClient.ts
@@ -167,6 +167,10 @@ export const tradeAPI = {
     const response = await apiClient.get(`/api/trades/${tradeId}`);
     return response.data.data;
   },
+  // 거래 생성
+  createTrade: async (postId: number): Promise<void> => {
+    await apiClient.post("/api/trades", { postId });
+  },
 };
 
 // 거래 관련 타입 정의


### PR DESCRIPTION
게시글 상세 페이지 구매하기 버튼 추가
구매하기 버튼 누르면 거래 생성 후 마이페이지로 이동
판매된 게시글은 판매완료 버튼으로 교체

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 특허 상세 페이지에 '구매하기' 버튼이 추가되어, 판매 중인 특허를 바로 구매할 수 있습니다. 구매 진행 시 버튼이 비활성화되고, 성공 또는 오류 알림이 표시됩니다.
* **버그 수정**
  * 판매 완료된 특허에는 '판매 완료' 버튼이 비활성화된 상태로 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->